### PR TITLE
Add option to install to updates subdir

### DIFF
--- a/kmodtool-kmodtool
+++ b/kmodtool-kmodtool
@@ -37,6 +37,7 @@ kernel_versions_to_build_for=
 prefix=
 filterfile=
 target=
+postfix_type="extra"
 
 error_out()
 {
@@ -52,7 +53,7 @@ print_rpmtemplate_header()
 {
 	echo
 	echo '%global kmodinstdir_prefix  '/usr/lib/modules/
-	echo '%global kmodinstdir_postfix '/extra/${kmodname}/
+	echo '%global kmodinstdir_postfix '/${postfix_type}/${kmodname}/
 	echo '%global kernel_versions     '${kernel_versions}
 	echo
 }
@@ -188,8 +189,8 @@ This package provides the ${kmodname} kernel modules built for the Linux
 kernel ${kernel_uname_r} for the %{_target_cpu} family of processors.
 %files        -n kmod-${kmodname}-${kernel_uname_r}
 %defattr(644,root,root,755)
-%dir /usr/lib/modules/${kernel_uname_r}/extra
-/usr/lib/modules/${kernel_uname_r}/extra/${kmodname}/
+%dir /usr/lib/modules/${kernel_uname_r}/${postfix_type}
+/usr/lib/modules/${kernel_uname_r}/${postfix_type}/${kmodname}/
 
 
 EOF
@@ -291,6 +292,7 @@ myprog_help ()
 	echo " --noakmod            -- no akmod package"
 	echo " --repo <name>        -- use buildsys-build-<name>-kerneldevpkgs"
 	echo " --target <arch>      -- target-arch (required)"
+	echo " --update             -- install modules into updates subfolder (default is extra)"
 }
 
 while [ "${1}" ] ; do
@@ -366,6 +368,10 @@ while [ "${1}" ] ; do
 		--current)
 			shift
 			build_kernels="current"
+			;;
+		--update)
+			shift
+			postfix_type="updates"
 			;;
 		--help)
 			myprog_help

--- a/kmodtool.spec
+++ b/kmodtool.spec
@@ -1,6 +1,6 @@
 Name:           kmodtool
 Version:        1
-Release:        23%{?dist}
+Release:        24%{?dist}
 Summary:        Tool for building kmod packages
 
 Group:          Development/Tools
@@ -51,6 +51,9 @@ rm -rf $RPM_BUILD_ROOT
 %{_datadir}/%{name}/
 
 %changelog
+* Fri Mar 10 2017 Felix Kaechele <felix@kaechele.ca> - 1-24
+- Add option to install modules into updates subfolder
+
 * Sat Dec 07 2013 Nicolas Chauvet <kwizart@gmail.com> - 1-23
 - Add support for lpae kernel variant for ARM
 


### PR DESCRIPTION
Sometimes you'd rather have kmodtool write the kmod files to the updates
folder of the kernel modules directory.

An example for this case would be any module that is installed by the
kernel-modules-extra package (which installs all it's modules to the
extra subfolder), because any kmod package that would also install
itself to the extra directory would not overload the existing modules
in that same directory.

Signed-off-by: Felix Kaechele <felix@kaechele.ca>